### PR TITLE
fix(ci): update repository tag format in images.yml

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -38,8 +38,8 @@ jobs:
           context: .
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/openllm-${{ matrix.app }}:${{ steps.get_sha.outputs.short_sha }}
-            ghcr.io/${{ github.repository_owner }}/openllm-${{ matrix.app }}:latest
+            ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ steps.get_sha.outputs.short_sha }}
+            ghcr.io/${{ github.repository }}-${{ matrix.app }}:latest
           target: ${{ matrix.app }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Updated Docker image tag format to use github.repository for consistency and accuracy in CI workflows.